### PR TITLE
Features/webhook calls

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -239,3 +239,13 @@ func (col *Collection) ToExtension() []*Extension {
 
 	return extension
 }
+
+// ToWebhookCall cast Items to WebhookCall model
+func (col *Collection) ToWebhookCall() []*WebhookCall {
+	var webhookCall []*WebhookCall
+
+	byteArray, _ := json.Marshal(col.Items)
+	_ = json.NewDecoder(bytes.NewReader(byteArray)).Decode(&webhookCall)
+
+	return webhookCall
+}

--- a/contentful.go
+++ b/contentful.go
@@ -43,6 +43,7 @@ type Client struct {
 	ScheduledActions   *ScheduledActionsService
 	Locales            *LocalesService
 	Webhooks           *WebhooksService
+	WebhookCalls       *WebhookCallsService
 	EditorInterfaces   *EditorInterfacesService
 	Extensions         *ExtensionsService
 }
@@ -85,6 +86,7 @@ func NewCMA(token string) *Client {
 	c.ScheduledActions = (*ScheduledActionsService)(&c.commonService)
 	c.Locales = (*LocalesService)(&c.commonService)
 	c.Webhooks = (*WebhooksService)(&c.commonService)
+	c.WebhookCalls = (*WebhookCallsService)(&c.commonService)
 	c.EditorInterfaces = (*EditorInterfacesService)(&c.commonService)
 	c.Extensions = (*ExtensionsService)(&c.commonService)
 	return c

--- a/go.sum
+++ b/go.sum
@@ -21,12 +21,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200325010219-a49f79bcc224 h1:azwY/v0y0K4mFHVsg5+UrTgchqALYWpqVo6vL5OmkmI=
-golang.org/x/tools v0.0.0-20200325010219-a49f79bcc224/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
-golang.org/x/tools v0.0.0-20200325203130-f53864d0dba1 h1:odiryKYJy7CjdrZxhrcE1Z8L9+kGyGZOnfpuauvdCeU=
-golang.org/x/tools v0.0.0-20200325203130-f53864d0dba1/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
-golang.org/x/tools v0.0.0-20200326210457-5d86d385bf88 h1:F7fM2kxXfuWw820fa+MMCCLH6hmYe+jtLnZpwoiLK4Q=
-golang.org/x/tools v0.0.0-20200326210457-5d86d385bf88/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200330040139-fa3cc9eebcfe h1:sOd+hT8wBUrIFR5Q6uQb/rg50z8NjHk96kC4adwvxjw=
 golang.org/x/tools v0.0.0-20200330040139-fa3cc9eebcfe/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/testdata/webhook_call.json
+++ b/testdata/webhook_call.json
@@ -1,0 +1,37 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 1,
+  "skip": 0,
+  "limit": 100,
+  "items": [
+    {
+      "sys": {
+        "type": "WebhookCallOverview",
+        "id": "bar",
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "yadj1kx9rmg0"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "WebhookDefinition",
+            "id": "foobar"
+          }
+        },
+        "createdAt": "2016-03-01T08:43:22.024Z"
+      },
+      "statusCode": 200,
+      "errors": [],
+      "eventType": "publish",
+      "url": "https://webhooks.example.com/endpoint",
+      "requestAt": "2016-03-01T08:43:22.024Z",
+      "responseAt": "2016-03-01T08:43:22.330Z"
+    }
+  ]
+}

--- a/testdata/webhook_call_detail.json
+++ b/testdata/webhook_call_detail.json
@@ -1,0 +1,45 @@
+{
+  "sys": {
+    "type": "WebhookCallDetails",
+    "id": "bar",
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "yadj1kx9rmg0"
+      }
+    },
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "WebhookDefinition",
+        "id": "foobar"
+      }
+    },
+    "createdAt": "2016-03-01T08:43:22.024Z"
+  },
+  "request": {
+    "url": "https://webhooks.example.com/endpoint",
+    "method": "POST",
+    "headers": {
+      "X-Contentful-Topic": "ContentManagement.Entry.publish",
+      "Content-Type": "application/vnd.contentful.management.v1+json"
+    },
+    "body": "{}"
+  },
+  "response": {
+    "url": "https://webhooks.example.com/endpoint",
+    "headers": {
+      "Content-Type": "text/html; charset=utf-8",
+      "Content-Length": "2"
+    },
+    "body": "ok",
+    "statusCode": 200
+  },
+  "statusCode": 200,
+  "errors": [],
+  "eventType": "publish",
+  "url": "https://webhooks.example.com/endpoint",
+  "requestAt": "2016-03-01T08:43:22.024Z",
+  "responseAt": "2016-03-01T08:43:22.330Z"
+}

--- a/testdata/webhook_health.json
+++ b/testdata/webhook_health.json
@@ -1,0 +1,24 @@
+{
+  "sys": {
+    "type": "Webhook",
+    "id": "bar",
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "yadj1kx9rmg0"
+      }
+    },
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "WebhookDefinition",
+        "id": "foobar"
+      }
+    }
+  },
+  "calls": {
+    "total": 233,
+    "healthy": 102
+  }
+}

--- a/webhook_call.go
+++ b/webhook_call.go
@@ -3,6 +3,7 @@ package contentful
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // WebhookCallsService service
@@ -11,12 +12,42 @@ type WebhookCallsService service
 // WebhookCall model
 type WebhookCall struct {
 	Sys        *Sys     `json:"sys"`
+	Request    Request  `json:"request,omitempty"`
+	Response   Response `json:"response,omitempty"`
 	StatusCode int      `json:"statusCode"`
 	Errors     []string `json:"errors"`
 	EventType  string   `json:"eventType"`
 	URL        string   `json:"url"`
 	RequestAt  string   `json:"requestAt"`
 	ResponseAt string   `json:"responseAt"`
+}
+
+// Request model
+type Request struct {
+	URL     string            `json:"url"`
+	Method  string            `json:"method"`
+	Headers map[string]string `json:"headers"`
+	Body    string            `json:"body"`
+}
+
+// Response model
+type Response struct {
+	URL        string            `json:"url"`
+	Headers    map[string]string `json:"headers"`
+	Body       string            `json:"body"`
+	StatusCode int               `json:"statusCode"`
+}
+
+// WebhookHealth model
+type WebhookHealth struct {
+	Sys   *Sys          `json:"sys"`
+	Calls HealthDetails `json:"calls"`
+}
+
+// HealthDetails model
+type HealthDetails struct {
+	Total   int `json:"total"`
+	Healthy int `json:"healthy"`
 }
 
 // GetVersion returns entity version
@@ -29,7 +60,7 @@ func (webhookCall *WebhookCall) GetVersion() int {
 	return version
 }
 
-// List returns entries collection
+// List returns a webhook calls collection
 func (service *WebhookCallsService) List(spaceID, webhookID string) *Collection {
 	path := fmt.Sprintf("/spaces/%s/webhooks/%s/calls", spaceID, webhookID)
 
@@ -43,4 +74,42 @@ func (service *WebhookCallsService) List(spaceID, webhookID string) *Collection 
 	col.req = req
 
 	return col
+}
+
+// Get returns details of a single webhook call
+func (service *WebhookCallsService) Get(spaceID, webhookID, callID string) (*WebhookCall, error) {
+	path := fmt.Sprintf("/spaces/%s/webhooks/%s/calls/%s", spaceID, webhookID, callID)
+	query := url.Values{}
+	method := "GET"
+
+	req, err := service.c.newRequest(method, path, query, nil)
+	if err != nil {
+		return &WebhookCall{}, err
+	}
+
+	var webHook WebhookCall
+	if ok := service.c.do(req, &webHook); ok != nil {
+		return nil, err
+	}
+
+	return &webHook, err
+}
+
+// Health returns the health of a webhook
+func (service *WebhookCallsService) Health(spaceID, webhookID string) (*WebhookHealth, error) {
+	path := fmt.Sprintf("/spaces/%s/webhooks/%s/health", spaceID, webhookID)
+	query := url.Values{}
+	method := "GET"
+
+	req, err := service.c.newRequest(method, path, query, nil)
+	if err != nil {
+		return &WebhookHealth{}, err
+	}
+
+	var health WebhookHealth
+	if ok := service.c.do(req, &health); ok != nil {
+		return nil, err
+	}
+
+	return &health, err
 }

--- a/webhook_call.go
+++ b/webhook_call.go
@@ -1,0 +1,46 @@
+package contentful
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// WebhookCallsService service
+type WebhookCallsService service
+
+// WebhookCall model
+type WebhookCall struct {
+	Sys        *Sys     `json:"sys"`
+	StatusCode int      `json:"statusCode"`
+	Errors     []string `json:"errors"`
+	EventType  string   `json:"eventType"`
+	URL        string   `json:"url"`
+	RequestAt  string   `json:"requestAt"`
+	ResponseAt string   `json:"responseAt"`
+}
+
+// GetVersion returns entity version
+func (webhookCall *WebhookCall) GetVersion() int {
+	version := 1
+	if webhookCall.Sys != nil {
+		version = webhookCall.Sys.Version
+	}
+
+	return version
+}
+
+// List returns entries collection
+func (service *WebhookCallsService) List(spaceID, webhookID string) *Collection {
+	path := fmt.Sprintf("/spaces/%s/webhooks/%s/calls", spaceID, webhookID)
+
+	req, err := service.c.newRequest(http.MethodGet, path, nil, nil)
+	if err != nil {
+		return &Collection{}
+	}
+
+	col := NewCollection(&CollectionOptions{})
+	col.c = service.c
+	col.req = req
+
+	return col
+}

--- a/webhook_call.go
+++ b/webhook_call.go
@@ -50,16 +50,6 @@ type HealthDetails struct {
 	Healthy int `json:"healthy"`
 }
 
-// GetVersion returns entity version
-func (webhookCall *WebhookCall) GetVersion() int {
-	version := 1
-	if webhookCall.Sys != nil {
-		version = webhookCall.Sys.Version
-	}
-
-	return version
-}
-
 // List returns a webhook calls collection
 func (service *WebhookCallsService) List(spaceID, webhookID string) *Collection {
 	path := fmt.Sprintf("/spaces/%s/webhooks/%s/calls", spaceID, webhookID)

--- a/webhook_call_test.go
+++ b/webhook_call_test.go
@@ -1,0 +1,40 @@
+package contentful
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebhookCallsService_List(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "GET")
+		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/webhooks/0KzM2HxYr5O1pZ4SaUzK8h/calls")
+
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, readTestData("webhook_call.json"))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	collection, err := cma.WebhookCalls.List(spaceID, "0KzM2HxYr5O1pZ4SaUzK8h").Next()
+	assertions.Nil(err)
+
+	spaces := collection.ToWebhookCall()
+	assertions.Equal(1, len(spaces))
+	assertions.Equal("bar", spaces[0].Sys.ID)
+}

--- a/webhook_call_test.go
+++ b/webhook_call_test.go
@@ -38,3 +38,59 @@ func TestWebhookCallsService_List(t *testing.T) {
 	assertions.Equal(1, len(spaces))
 	assertions.Equal("bar", spaces[0].Sys.ID)
 }
+
+func TestWebhookCallsService_Get(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "GET")
+		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/webhooks/0KzM2HxYr5O1pZ4SaUzK8h/calls/bar")
+
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, readTestData("webhook_call_detail.json"))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	callDetails, err := cma.WebhookCalls.Get(spaceID, "0KzM2HxYr5O1pZ4SaUzK8h", "bar")
+	assertions.Nil(err)
+	assertions.Equal("bar", callDetails.Sys.ID)
+	assertions.Equal("https://webhooks.example.com/endpoint", callDetails.Request.URL)
+}
+
+func TestWebhookCallsService_Health(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "GET")
+		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/webhooks/0KzM2HxYr5O1pZ4SaUzK8h/health")
+
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, readTestData("webhook_health.json"))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	health, err := cma.WebhookCalls.Health(spaceID, "0KzM2HxYr5O1pZ4SaUzK8h")
+	assertions.Nil(err)
+	assertions.Equal("bar", health.Sys.ID)
+	assertions.Equal(233, health.Calls.Total)
+}


### PR DESCRIPTION
[CP-38], [CP-39], [CP-40] Added support for all endpoints of the webhook calls in the Content Management API.

Created a new service webhook calls and the corresponding unit tests for each method.