### PR TITLE
Features/app definitions

### DIFF
--- a/app_definition.go
+++ b/app_definition.go
@@ -97,3 +97,16 @@ func (service *AppDefinitionsService) Upsert(organizationID string, definition *
 
 	return service.c.do(req, definition)
 }
+
+// Delete the app definition
+func (service *AppDefinitionsService) Delete(organizationID, appDefinitionID string) error {
+	path := fmt.Sprintf("/organizations/%s/app_definitions/%s", organizationID, appDefinitionID)
+	method := "DELETE"
+
+	req, err := service.c.newRequest(method, path, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	return service.c.do(req, nil)
+}

--- a/app_definition.go
+++ b/app_definition.go
@@ -3,6 +3,7 @@ package contentful
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // AppDefinitionsService service
@@ -45,4 +46,23 @@ func (service *AppDefinitionsService) List(organizationID string) *Collection {
 	col.req = req
 
 	return col
+}
+
+// Get returns a single entry
+func (service *AppDefinitionsService) Get(organizationID, appDefinitionID string) (*AppDefinition, error) {
+	path := fmt.Sprintf("/organizations/%s/app_definitions/%s", organizationID, appDefinitionID)
+	query := url.Values{}
+	method := "GET"
+
+	req, err := service.c.newRequest(method, path, query, nil)
+	if err != nil {
+		return &AppDefinition{}, err
+	}
+
+	var definition AppDefinition
+	if ok := service.c.do(req, &definition); ok != nil {
+		return nil, err
+	}
+
+	return &definition, err
 }

--- a/app_definition.go
+++ b/app_definition.go
@@ -1,0 +1,48 @@
+package contentful
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// AppDefinitionsService service
+type AppDefinitionsService service
+
+// AppDefinition model
+type AppDefinition struct {
+	Sys       *Sys        `json:"sys"`
+	Name      string      `json:"name"`
+	SRC       string      `json:"src"`
+	Locations []Locations `json:"locations"`
+}
+
+// Locations model
+type Locations struct {
+	Location string `json:"location"`
+}
+
+// GetVersion returns entity version
+func (appDefinition *AppDefinition) GetVersion() int {
+	version := 1
+	if appDefinition.Sys != nil {
+		version = appDefinition.Sys.Version
+	}
+
+	return version
+}
+
+// List returns an app definitions collection
+func (service *AppDefinitionsService) List(organizationID string) *Collection {
+	path := fmt.Sprintf("/organizations/%s/app_definitions", organizationID)
+
+	req, err := service.c.newRequest(http.MethodGet, path, nil, nil)
+	if err != nil {
+		return &Collection{}
+	}
+
+	col := NewCollection(&CollectionOptions{})
+	col.c = service.c
+	col.req = req
+
+	return col
+}

--- a/app_definition_test.go
+++ b/app_definition_test.go
@@ -1,0 +1,40 @@
+package contentful
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAppDefinitionsService_List(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "GET")
+		assertions.Equal(r.URL.Path, "/organizations/organization_id/app_definitions")
+
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, readTestData("app_definition.json"))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	collection, err := cma.AppDefinitions.List("organization_id").Next()
+	assertions.Nil(err)
+
+	definitions := collection.ToAppDefinition()
+	assertions.Equal(1, len(definitions))
+	assertions.Equal("app_definition_id", definitions[0].Sys.ID)
+	assertions.Equal("https://example.com/app.html", definitions[0].SRC)
+}

--- a/app_definition_test.go
+++ b/app_definition_test.go
@@ -76,11 +76,11 @@ func TestAppDefinitionsService_Upsert_Create(t *testing.T) {
 		assertions.Equal(r.RequestURI, "/organizations/organization_id/app_definitions")
 		checkHeaders(r, assertions)
 
-		//var payload map[string]interface{}
-		//err := json.NewDecoder(r.Body).Decode(&payload)
-		//assertions.Nil(err)
-		//assertions.Equal("new space", payload["name"])
-		//assertions.Equal("en", payload["defaultLocale"])
+		var payload map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&payload)
+		assertions.Nil(err)
+		assertions.Equal("Hello Pluto", payload["name"])
+		assertions.Equal("https://example.com/hellopluto.html", payload["src"])
 
 		w.WriteHeader(201)
 		_, _ = fmt.Fprintln(w, string(readTestData("app_definition_1.json")))

--- a/app_definition_test.go
+++ b/app_definition_test.go
@@ -1,6 +1,7 @@
 package contentful
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"net/http"
@@ -65,4 +66,85 @@ func TestAppDefinitionsService_Get(t *testing.T) {
 	assertions.Nil(err)
 	assertions.Equal("app_definition_id", definition.Sys.ID)
 	assertions.Equal("Hello world!", definition.Name)
+}
+
+func TestAppDefinitionsService_Upsert_Create(t *testing.T) {
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "POST")
+		assertions.Equal(r.RequestURI, "/organizations/organization_id/app_definitions")
+		checkHeaders(r, assertions)
+
+		//var payload map[string]interface{}
+		//err := json.NewDecoder(r.Body).Decode(&payload)
+		//assertions.Nil(err)
+		//assertions.Equal("new space", payload["name"])
+		//assertions.Equal("en", payload["defaultLocale"])
+
+		w.WriteHeader(201)
+		_, _ = fmt.Fprintln(w, string(readTestData("app_definition_1.json")))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	definition := &AppDefinition{
+		Name: "Hello world!",
+		SRC:  "https://example.com/app.html",
+		Locations: []Locations{
+			{
+				Location: "entry-sidebar",
+			},
+		},
+	}
+
+	err := cma.AppDefinitions.Upsert("organization_id", definition)
+	assertions.Nil(err)
+	assertions.Equal("app_definition_id", definition.Sys.ID)
+	assertions.Equal("Hello world!", definition.Name)
+}
+
+func TestAppDefinitionsService_Upsert_Update(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "PUT")
+		assertions.Equal(r.RequestURI, "/organizations/organization_id/app_definitions/app_definition_id")
+		checkHeaders(r, assertions)
+
+		var payload map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&payload)
+		assertions.Nil(err)
+		assertions.Equal("Hello Pluto", payload["name"])
+		assertions.Equal("https://example.com/hellopluto.html", payload["src"])
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, string(readTestData("app_definition_updated.json")))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	definition, err := appDefinitionFromTestData("app_definition_1.json")
+	assertions.Nil(err)
+
+	definition.Name = "Hello Pluto"
+	definition.SRC = "https://example.com/hellopluto.html"
+
+	err = cma.AppDefinitions.Upsert("organization_id", definition)
+	assertions.Nil(err)
+	assertions.Equal("Hello Pluto", definition.Name)
+	assertions.Equal("https://example.com/hellopluto.html", definition.SRC)
 }

--- a/app_definition_test.go
+++ b/app_definition_test.go
@@ -79,8 +79,8 @@ func TestAppDefinitionsService_Upsert_Create(t *testing.T) {
 		var payload map[string]interface{}
 		err := json.NewDecoder(r.Body).Decode(&payload)
 		assertions.Nil(err)
-		assertions.Equal("Hello Pluto", payload["name"])
-		assertions.Equal("https://example.com/hellopluto.html", payload["src"])
+		assertions.Equal("Hello world!", payload["name"])
+		assertions.Equal("https://example.com/app.html", payload["src"])
 
 		w.WriteHeader(201)
 		_, _ = fmt.Fprintln(w, string(readTestData("app_definition_1.json")))
@@ -147,4 +147,31 @@ func TestAppDefinitionsService_Upsert_Update(t *testing.T) {
 	assertions.Nil(err)
 	assertions.Equal("Hello Pluto", definition.Name)
 	assertions.Equal("https://example.com/hellopluto.html", definition.SRC)
+}
+
+func TestAppDefinitionsService_Delete(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "DELETE")
+		assertions.Equal(r.RequestURI, "/organizations/organization_id/app_definitions/app_definition_id")
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	definition, err := appDefinitionFromTestData("app_definition_1.json")
+	assertions.Nil(err)
+
+	err = cma.AppDefinitions.Delete("organization_id", definition.Sys.ID)
+	assertions.Nil(err)
 }

--- a/app_definition_test.go
+++ b/app_definition_test.go
@@ -38,3 +38,31 @@ func TestAppDefinitionsService_List(t *testing.T) {
 	assertions.Equal("app_definition_id", definitions[0].Sys.ID)
 	assertions.Equal("https://example.com/app.html", definitions[0].SRC)
 }
+
+func TestAppDefinitionsService_Get(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "GET")
+		assertions.Equal(r.URL.Path, "/organizations/organization_id/app_definitions/app_definition_id")
+
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, readTestData("app_definition_1.json"))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	definition, err := cma.AppDefinitions.Get("organization_id", "app_definition_id")
+	assertions.Nil(err)
+	assertions.Equal("app_definition_id", definition.Sys.ID)
+	assertions.Equal("Hello world!", definition.Name)
+}

--- a/collection.go
+++ b/collection.go
@@ -249,3 +249,13 @@ func (col *Collection) ToWebhookCall() []*WebhookCall {
 
 	return webhookCall
 }
+
+// ToAppDefinition cast Items to AppDefinition model
+func (col *Collection) ToAppDefinition() []*AppDefinition {
+	var appDefinitions []*AppDefinition
+
+	byteArray, _ := json.Marshal(col.Items)
+	_ = json.NewDecoder(bytes.NewReader(byteArray)).Decode(&appDefinitions)
+
+	return appDefinitions
+}

--- a/contentful.go
+++ b/contentful.go
@@ -46,6 +46,7 @@ type Client struct {
 	WebhookCalls       *WebhookCallsService
 	EditorInterfaces   *EditorInterfacesService
 	Extensions         *ExtensionsService
+	AppDefinitions     *AppDefinitionsService
 }
 
 type service struct {
@@ -89,6 +90,7 @@ func NewCMA(token string) *Client {
 	c.WebhookCalls = (*WebhookCallsService)(&c.commonService)
 	c.EditorInterfaces = (*EditorInterfacesService)(&c.commonService)
 	c.Extensions = (*ExtensionsService)(&c.commonService)
+	c.AppDefinitions = (*AppDefinitionsService)(&c.commonService)
 	return c
 }
 

--- a/contentful_test.go
+++ b/contentful_test.go
@@ -236,6 +236,18 @@ func extensionFromTestFile(fileName string) (*Extension, error) {
 	return &extension, nil
 }
 
+func appDefinitionFromTestData(fileName string) (*AppDefinition, error) {
+	content := readTestData(fileName)
+
+	var appDefinition AppDefinition
+	err := json.NewDecoder(strings.NewReader(content)).Decode(&appDefinition)
+	if err != nil {
+		return nil, err
+	}
+
+	return &appDefinition, nil
+}
+
 func setup() {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fixture := strings.Replace(r.URL.Path, "/", "-", -1)

--- a/testdata/app_definition.json
+++ b/testdata/app_definition.json
@@ -1,0 +1,46 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 1,
+  "skip": 0,
+  "limit": 100,
+  "items": [
+    {
+      "sys": {
+        "id": "app_definition_id",
+        "type": "AppDefinition",
+        "createdAt": "2020-01-01T13:00:00.000Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "7BslKh9TdKGOK41VmLDjFZ"
+          }
+        },
+        "updatedAt": "2020-01-01T13:00:00.000Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "7BslKh9TdKGOK41VmLDjFZ"
+          }
+        },
+        "organization": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Organization",
+            "id": "organization_id"
+          }
+        }
+      },
+      "name": "Hello world!",
+      "src": "https://example.com/app.html",
+      "locations": [
+        {
+          "location": "entry-sidebar"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/app_definition_1.json
+++ b/testdata/app_definition_1.json
@@ -1,0 +1,36 @@
+{
+  "sys": {
+    "id": "app_definition_id",
+    "type": "AppDefinition",
+    "createdAt": "2020-01-01T13:00:00.000Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "7BslKh9TdKGOK41VmLDjFZ"
+      }
+    },
+    "updatedAt": "2020-01-01T13:00:00.000Z",
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "7BslKh9TdKGOK41VmLDjFZ"
+      }
+    },
+    "organization": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Organization",
+        "id": "<organization_id>"
+      }
+    }
+  },
+  "name": "Hello world!",
+  "src": "https://example.com/app.html",
+  "locations": [
+    {
+      "location": "entry-sidebar"
+    }
+  ]
+}

--- a/testdata/app_definition_updated.json
+++ b/testdata/app_definition_updated.json
@@ -1,0 +1,36 @@
+{
+  "sys": {
+    "id": "app_definition_id",
+    "type": "AppDefinition",
+    "createdAt": "2020-01-01T13:00:00.000Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "7BslKh9TdKGOK41VmLDjFZ"
+      }
+    },
+    "updatedAt": "2020-01-01T13:00:00.000Z",
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "7BslKh9TdKGOK41VmLDjFZ"
+      }
+    },
+    "organization": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Organization",
+        "id": "<organization_id>"
+      }
+    }
+  },
+  "name": "Hello Pluto",
+  "src": "https://example.com/hellopluto.html",
+  "locations": [
+    {
+      "location": "entry-sidebar"
+    }
+  ]
+}


### PR DESCRIPTION
[CP-67], [CP-68], [CP-69], [CP-70], [CP-71] Added support for all app definitions endpoints in the Content Management API.

New code is written in the new AppDefinitions service and the corresponding _test file. 