### PR TITLE
Features/app installations

### DIFF
--- a/app_definition_test.go
+++ b/app_definition_test.go
@@ -137,7 +137,7 @@ func TestAppDefinitionsService_Upsert_Update(t *testing.T) {
 	cma = NewCMA(CMAToken)
 	cma.BaseURL = server.URL
 
-	definition, err := appDefinitionFromTestData("app_definition_1.json")
+	definition, err := appDefinitionFromTestFile("app_definition_1.json")
 	assertions.Nil(err)
 
 	definition.Name = "Hello Pluto"
@@ -169,7 +169,7 @@ func TestAppDefinitionsService_Delete(t *testing.T) {
 	cma = NewCMA(CMAToken)
 	cma.BaseURL = server.URL
 
-	definition, err := appDefinitionFromTestData("app_definition_1.json")
+	definition, err := appDefinitionFromTestFile("app_definition_1.json")
 	assertions.Nil(err)
 
 	err = cma.AppDefinitions.Delete("organization_id", definition.Sys.ID)

--- a/app_installation.go
+++ b/app_installation.go
@@ -1,0 +1,61 @@
+package contentful
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// AppInstallationsService service
+type AppInstallationsService service
+
+// AppInstallation model
+type AppInstallation struct {
+	Sys        *Sys              `json:"sys"`
+	Parameters map[string]string `json:"parameters"`
+}
+
+// GetVersion returns entity version
+func (appInstallation *AppInstallation) GetVersion() int {
+	version := 1
+	if appInstallation.Sys != nil {
+		version = appInstallation.Sys.Version
+	}
+
+	return version
+}
+
+// List returns an app installations collection
+func (service *AppInstallationsService) List(spaceID string) *Collection {
+	path := fmt.Sprintf("/spaces/%s/environments/%s/app_installations", spaceID, service.c.Environment)
+
+	req, err := service.c.newRequest(http.MethodGet, path, nil, nil)
+	if err != nil {
+		return &Collection{}
+	}
+
+	col := NewCollection(&CollectionOptions{})
+	col.c = service.c
+	col.req = req
+
+	return col
+}
+
+// Get returns a single app installation
+func (service *AppInstallationsService) Get(spaceID, appDefinitionID string) (*AppInstallation, error) {
+	path := fmt.Sprintf("/spaces/%s/environments/%s/app_installations/%s", spaceID, service.c.Environment, appDefinitionID)
+	query := url.Values{}
+	method := "GET"
+
+	req, err := service.c.newRequest(method, path, query, nil)
+	if err != nil {
+		return &AppInstallation{}, err
+	}
+
+	var installation AppInstallation
+	if ok := service.c.do(req, &installation); ok != nil {
+		return nil, err
+	}
+
+	return &installation, err
+}

--- a/app_installation.go
+++ b/app_installation.go
@@ -90,3 +90,16 @@ func (service *AppInstallationsService) Upsert(spaceID, appDefinitionID string, 
 
 	return service.c.do(req, installation)
 }
+
+// Delete the entry
+func (service *AppInstallationsService) Delete(spaceID, appDefinitionID string) error {
+	path := fmt.Sprintf("/spaces/%s/environments/%s/app_installations/%s", spaceID, service.c.Environment, appDefinitionID)
+	method := "DELETE"
+
+	req, err := service.c.newRequest(method, path, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	return service.c.do(req, nil)
+}

--- a/app_installation_test.go
+++ b/app_installation_test.go
@@ -1,6 +1,7 @@
 package contentful
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"net/http"
@@ -63,4 +64,78 @@ func TestAppInstallationsService_Get(t *testing.T) {
 	installation, err := cma.AppInstallations.Get(spaceID, "app_definition_id")
 	assertions.Nil(err)
 	assertions.Equal("world", installation.Parameters["hello"])
+}
+
+func TestAppInstallationsService_Upsert_Create(t *testing.T) {
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "POST")
+		assertions.Equal(r.RequestURI, "/spaces/"+spaceID+"/environments/master/app_installations")
+		checkHeaders(r, assertions)
+
+		var payload map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&payload)
+		assertions.Nil(err)
+		parameters := payload["parameters"].(map[string]interface{})
+		assertions.Equal("world", parameters["hello"])
+
+		w.WriteHeader(201)
+		_, _ = fmt.Fprintln(w, string(readTestData("app_installation_1.json")))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	installation := &AppInstallation{
+		Parameters: map[string]string{
+			"hello": "world",
+		},
+	}
+
+	err := cma.AppInstallations.Upsert(spaceID, "", installation)
+	assertions.Nil(err)
+	assertions.Equal("world", installation.Parameters["hello"])
+}
+
+func TestAppInstallationsService_Upsert_Update(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "PUT")
+		assertions.Equal(r.RequestURI, "/spaces/"+spaceID+"/environments/master/app_installations/app_definition_id")
+		checkHeaders(r, assertions)
+
+		var payload map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&payload)
+		assertions.Nil(err)
+		parameters := payload["parameters"].(map[string]interface{})
+		assertions.Equal("ipsum", parameters["lorum"])
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, string(readTestData("app_installation_updated.json")))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	installation, err := appInstallationFromTestFile("app_installation_1.json")
+	assertions.Nil(err)
+
+	installation.Parameters["lorum"] = "ipsum"
+
+	err = cma.AppInstallations.Upsert(spaceID, "app_definition_id", installation)
+	assertions.Nil(err)
+	assertions.Equal("ipsum", installation.Parameters["lorum"])
 }

--- a/app_installation_test.go
+++ b/app_installation_test.go
@@ -1,0 +1,66 @@
+package contentful
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAppInstallationsService_List(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "GET")
+		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/environments/master/app_installations")
+
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, readTestData("app_installation.json"))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	collection, err := cma.AppInstallations.List(spaceID).Next()
+	assertions.Nil(err)
+
+	installation := collection.ToAppInstallation()
+	assertions.Equal(1, len(installation))
+	assertions.Equal("world", installation[0].Parameters["hello"])
+}
+
+func TestAppInstallationsService_Get(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "GET")
+		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/environments/master/app_installations/app_definition_id")
+
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, readTestData("app_installation_1.json"))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	installation, err := cma.AppInstallations.Get(spaceID, "app_definition_id")
+	assertions.Nil(err)
+	assertions.Equal("world", installation.Parameters["hello"])
+}

--- a/app_installation_test.go
+++ b/app_installation_test.go
@@ -139,3 +139,27 @@ func TestAppInstallationsService_Upsert_Update(t *testing.T) {
 	assertions.Nil(err)
 	assertions.Equal("ipsum", installation.Parameters["lorum"])
 }
+
+func TestAppInstallationsService_Delete(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "DELETE")
+		assertions.Equal(r.RequestURI, "/spaces/"+spaceID+"/environments/master/app_installations/app_definition_id")
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	err = cma.AppInstallations.Delete(spaceID, "app_definition_id")
+	assertions.Nil(err)
+}

--- a/collection.go
+++ b/collection.go
@@ -259,3 +259,13 @@ func (col *Collection) ToAppDefinition() []*AppDefinition {
 
 	return appDefinitions
 }
+
+// ToAppInstallation cast Items to AppInstallation model
+func (col *Collection) ToAppInstallation() []*AppInstallation {
+	var appInstallation []*AppInstallation
+
+	byteArray, _ := json.Marshal(col.Items)
+	_ = json.NewDecoder(bytes.NewReader(byteArray)).Decode(&appInstallation)
+
+	return appInstallation
+}

--- a/contentful.go
+++ b/contentful.go
@@ -47,6 +47,7 @@ type Client struct {
 	EditorInterfaces   *EditorInterfacesService
 	Extensions         *ExtensionsService
 	AppDefinitions     *AppDefinitionsService
+	AppInstallations   *AppInstallationsService
 }
 
 type service struct {
@@ -91,6 +92,7 @@ func NewCMA(token string) *Client {
 	c.EditorInterfaces = (*EditorInterfacesService)(&c.commonService)
 	c.Extensions = (*ExtensionsService)(&c.commonService)
 	c.AppDefinitions = (*AppDefinitionsService)(&c.commonService)
+	c.AppInstallations = (*AppInstallationsService)(&c.commonService)
 	return c
 }
 

--- a/contentful_test.go
+++ b/contentful_test.go
@@ -236,7 +236,7 @@ func extensionFromTestFile(fileName string) (*Extension, error) {
 	return &extension, nil
 }
 
-func appDefinitionFromTestData(fileName string) (*AppDefinition, error) {
+func appDefinitionFromTestFile(fileName string) (*AppDefinition, error) {
 	content := readTestData(fileName)
 
 	var appDefinition AppDefinition
@@ -246,6 +246,18 @@ func appDefinitionFromTestData(fileName string) (*AppDefinition, error) {
 	}
 
 	return &appDefinition, nil
+}
+
+func appInstallationFromTestFile(fileName string) (*AppInstallation, error) {
+	content := readTestData(fileName)
+
+	var appInstallation AppInstallation
+	err := json.NewDecoder(strings.NewReader(content)).Decode(&appInstallation)
+	if err != nil {
+		return nil, err
+	}
+
+	return &appInstallation, nil
 }
 
 func setup() {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.1.4
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/tools v0.0.0-20200330040139-fa3cc9eebcfe // indirect
+	golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4 // indirect
 	moul.io/http2curl v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200330040139-fa3cc9eebcfe h1:sOd+hT8wBUrIFR5Q6uQb/rg50z8NjHk96kC4adwvxjw=
 golang.org/x/tools v0.0.0-20200330040139-fa3cc9eebcfe/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
+golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4 h1:kDtqNkeBrZb8B+atrj50B5XLHpzXXqcCdZPP/ApQ5NY=
+golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/testdata/app_installation.json
+++ b/testdata/app_installation.json
@@ -1,0 +1,55 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 1,
+  "skip": 0,
+  "limit": 100,
+  "items": [
+    {
+      "sys": {
+        "type": "AppInstallation",
+        "appDefinition": {
+          "sys": {
+            "type": "Link",
+            "linkType": "AppDefinition",
+            "id": "<app_definition_id>"
+          }
+        },
+        "createdAt": "2020-01-01T13:00:00.000Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "7BslKh9TdKGOK41VmLDjFZ"
+          }
+        },
+        "updatedAt": "2020-01-01T13:00:00.000Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "7BslKh9TdKGOK41VmLDjFZ"
+          }
+        },
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "yadj1kx9rmg0"
+          }
+        },
+        "environment": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Environment",
+            "id": "staging"
+          }
+        }
+      },
+      "parameters": {
+        "hello": "world"
+      }
+    }
+  ]
+}

--- a/testdata/app_installation_1.json
+++ b/testdata/app_installation_1.json
@@ -1,0 +1,45 @@
+{
+  "sys": {
+    "type": "AppInstallation",
+    "appDefinition": {
+      "sys": {
+        "type": "Link",
+        "linkType": "AppDefinition",
+        "id": "<app_definition_id>"
+      }
+    },
+    "createdAt": "2020-01-01T13:00:00.000Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "7BslKh9TdKGOK41VmLDjFZ"
+      }
+    },
+    "updatedAt": "2020-01-01T13:00:00.000Z",
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "7BslKh9TdKGOK41VmLDjFZ"
+      }
+    },
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "yadj1kx9rmg0"
+      }
+    },
+    "environment": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Environment",
+        "id": "staging"
+      }
+    }
+  },
+  "parameters": {
+    "hello": "world"
+  }
+}

--- a/testdata/app_installation_updated.json
+++ b/testdata/app_installation_updated.json
@@ -1,0 +1,45 @@
+{
+  "sys": {
+    "type": "AppInstallation",
+    "appDefinition": {
+      "sys": {
+        "type": "Link",
+        "linkType": "AppDefinition",
+        "id": "<app_definition_id>"
+      }
+    },
+    "createdAt": "2020-01-01T13:00:00.000Z",
+    "createdBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "7BslKh9TdKGOK41VmLDjFZ"
+      }
+    },
+    "updatedAt": "2020-01-01T13:00:00.000Z",
+    "updatedBy": {
+      "sys": {
+        "type": "Link",
+        "linkType": "User",
+        "id": "7BslKh9TdKGOK41VmLDjFZ"
+      }
+    },
+    "space": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Space",
+        "id": "yadj1kx9rmg0"
+      }
+    },
+    "environment": {
+      "sys": {
+        "type": "Link",
+        "linkType": "Environment",
+        "id": "staging"
+      }
+    }
+  },
+  "parameters": {
+    "lorum": "ipsum"
+  }
+}


### PR DESCRIPTION
[CP-72], [CP-73], [CP-74], [CP-75] Added support for all appInstallations endpoints in the Content Management API. 

Created the AppInstallations service containing all service methods and created the _test file with the corresponding unit tests.