### PR TITLE
Features/usage

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -269,3 +269,13 @@ func (col *Collection) ToAppInstallation() []*AppInstallation {
 
 	return appInstallation
 }
+
+// ToUsage cast Items to Usage model
+func (col *Collection) ToUsage() []*Usage {
+	var usage []*Usage
+
+	byteArray, _ := json.Marshal(col.Items)
+	_ = json.NewDecoder(bytes.NewReader(byteArray)).Decode(&usage)
+
+	return usage
+}

--- a/contentful.go
+++ b/contentful.go
@@ -48,6 +48,7 @@ type Client struct {
 	Extensions         *ExtensionsService
 	AppDefinitions     *AppDefinitionsService
 	AppInstallations   *AppInstallationsService
+	Usages             *UsagesService
 }
 
 type service struct {
@@ -93,6 +94,7 @@ func NewCMA(token string) *Client {
 	c.Extensions = (*ExtensionsService)(&c.commonService)
 	c.AppDefinitions = (*AppDefinitionsService)(&c.commonService)
 	c.AppInstallations = (*AppInstallationsService)(&c.commonService)
+	c.Usages = (*UsagesService)(&c.commonService)
 	return c
 }
 

--- a/organization.go
+++ b/organization.go
@@ -23,9 +23,33 @@ func (o *Organization) GetVersion() int {
 	return version
 }
 
-// List returns an environments collection
+// List returns an organizations collection
 func (service *OrganizationsService) List() *Collection {
 	path := fmt.Sprintf("/organizations")
+	method := "GET"
+
+	req, err := service.c.newRequest(method, path, nil, nil)
+	if err != nil {
+		return nil
+	}
+
+	col := NewCollection(&CollectionOptions{})
+	col.c = service.c
+	col.req = req
+
+	return col
+}
+
+// GetUsage returns the usage of the specified organization
+func (service *OrganizationsService) GetUsage(organizationID, orderBy, metric, startAt, endAt string) *Collection {
+	path := fmt.Sprintf(
+		"/organizations/%s/space_periodic_usages?order=%s&metric[in]=%s&dateRange.startAt=%s&dateRange.endAt=%s",
+		organizationID,
+		orderBy,
+		metric,
+		startAt,
+		endAt,
+	)
 	method := "GET"
 
 	req, err := service.c.newRequest(method, path, nil, nil)

--- a/organization.go
+++ b/organization.go
@@ -39,27 +39,3 @@ func (service *OrganizationsService) List() *Collection {
 
 	return col
 }
-
-// GetUsage returns the usage of the specified organization
-func (service *OrganizationsService) GetUsage(organizationID, orderBy, metric, startAt, endAt string) *Collection {
-	path := fmt.Sprintf(
-		"/organizations/%s/space_periodic_usages?order=%s&metric[in]=%s&dateRange.startAt=%s&dateRange.endAt=%s",
-		organizationID,
-		orderBy,
-		metric,
-		startAt,
-		endAt,
-	)
-	method := "GET"
-
-	req, err := service.c.newRequest(method, path, nil, nil)
-	if err != nil {
-		return nil
-	}
-
-	col := NewCollection(&CollectionOptions{})
-	col.c = service.c
-	col.req = req
-
-	return col
-}

--- a/organization_test.go
+++ b/organization_test.go
@@ -34,33 +34,3 @@ func TestOrganizationsServiceList(t *testing.T) {
 	_, err = cma.Organizations.List().Next()
 	assertions.Nil(err)
 }
-
-func TestOrganizationsService_GetUsage(t *testing.T) {
-	var err error
-	assertions := assert.New(t)
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assertions.Equal(r.Method, "GET")
-		assertions.Equal(r.URL.Path, "/organizations/organization_id/space_periodic_usages?order=-usage&metric[in]=cma,cpa,gql&dateRange.startAt=2020-01-01&dateRange.endAt=2020-01-03")
-
-		checkHeaders(r, assertions)
-
-		w.WriteHeader(200)
-		_, _ = fmt.Fprintln(w, readTestData("usage_organization.json"))
-	})
-
-	// test server
-	server := httptest.NewServer(handler)
-	defer server.Close()
-
-	// cma client
-	cma = NewCMA(CMAToken)
-	cma.BaseURL = server.URL
-
-	res, err := cma.Organizations.GetUsage("organization_id", "-usage", "cma,cpa,gql", "2020-01-01", "2020-01-03").Next()
-	assertions.Nil(err)
-
-	usage := res.ToUsage()
-	assertions.Equal(1, len(usage))
-	assertions.Equal("<usage_metric_id>", usage[0].Sys.ID)
-}

--- a/organization_test.go
+++ b/organization_test.go
@@ -34,3 +34,33 @@ func TestOrganizationsServiceList(t *testing.T) {
 	_, err = cma.Organizations.List().Next()
 	assertions.Nil(err)
 }
+
+func TestOrganizationsService_GetUsage(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "GET")
+		assertions.Equal(r.URL.Path, "/organizations/organization_id/space_periodic_usages?order=-usage&metric[in]=cma,cpa,gql&dateRange.startAt=2020-01-01&dateRange.endAt=2020-01-03")
+
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, readTestData("usage_organization.json"))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	res, err := cma.Organizations.GetUsage("organization_id", "-usage", "cma,cpa,gql", "2020-01-01", "2020-01-03").Next()
+	assertions.Nil(err)
+
+	usage := res.ToUsage()
+	assertions.Equal(1, len(usage))
+	assertions.Equal("<usage_metric_id>", usage[0].Sys.ID)
+}

--- a/testdata/usage_organization.json
+++ b/testdata/usage_organization.json
@@ -1,0 +1,35 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 100,
+  "skip": 0,
+  "limit": 25,
+  "items": [
+    {
+      "sys": {
+        "id": "<usage_metric_id>",
+        "type": "OrganizationPeriodicUsage",
+        "organization": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Organization",
+            "id": "organization_id"
+          }
+        }
+      },
+      "unitOfMeasure": "apiRequestCount",
+      "metric": "cma",
+      "dateRange": {
+        "startAt": "2020-01-01",
+        "endAt": "2020-01-03"
+      },
+      "usage": 100,
+      "usagePerDay": {
+        "2020-01-01": 30,
+        "2020-01-02": 30,
+        "2020-01-03": 40
+      }
+    }
+  ]
+}

--- a/testdata/usage_space.json
+++ b/testdata/usage_space.json
@@ -1,0 +1,35 @@
+{
+  "sys": {
+    "type": "Array"
+  },
+  "total": 100,
+  "skip": 0,
+  "limit": 25,
+  "items": [
+    {
+      "sys": {
+        "id": "<usage_metric_id>",
+        "type": "SpacePeriodicUsage",
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "yadj1kx9rmg0"
+          }
+        }
+      },
+      "unitOfMeasure": "apiRequestCount",
+      "metric": "cma",
+      "dateRange": {
+        "startAt": "2020-01-01",
+        "endAt": "2020-01-03"
+      },
+      "usage": 100,
+      "usagePerDay": {
+        "2020-01-01": 30,
+        "2020-01-02": 30,
+        "2020-01-03": 40
+      }
+    }
+  ]
+}

--- a/usage.go
+++ b/usage.go
@@ -1,0 +1,17 @@
+package contentful
+
+// Usage model
+type Usage struct {
+	Sys           *Sys              `json:"sys"`
+	UnitOfMeasure string            `json:"unitOfMeasure"`
+	Metric        string            `json:"metric"`
+	DateRange     DateRange         `json:"dateRange"`
+	TotalUsage    int               `json:"usage"`
+	UsagePerDay   map[string]string `json:"usagePerDay"`
+}
+
+// DateRange model
+type DateRange struct {
+	StartAt string `json:"startAt"`
+	EndAt   string `json:"endAt"`
+}

--- a/usage.go
+++ b/usage.go
@@ -1,5 +1,10 @@
 package contentful
 
+import "fmt"
+
+// UsagesService service
+type UsagesService service
+
 // Usage model
 type Usage struct {
 	Sys           *Sys              `json:"sys"`
@@ -14,4 +19,52 @@ type Usage struct {
 type DateRange struct {
 	StartAt string `json:"startAt"`
 	EndAt   string `json:"endAt"`
+}
+
+// GetOrganizationUsage returns the usage of the specified organization
+func (service *UsagesService) GetOrganizationUsage(organizationID, orderBy, metric, startAt, endAt string) *Collection {
+	path := fmt.Sprintf(
+		"/organizations/%s/organization_periodic_usages?order=%s&metric[in]=%s&dateRange.startAt=%s&dateRange.endAt=%s",
+		organizationID,
+		orderBy,
+		metric,
+		startAt,
+		endAt,
+	)
+	method := "GET"
+
+	req, err := service.c.newRequest(method, path, nil, nil)
+	if err != nil {
+		return nil
+	}
+
+	col := NewCollection(&CollectionOptions{})
+	col.c = service.c
+	col.req = req
+
+	return col
+}
+
+// GetSpaceUsage returns the organization usage by space
+func (service *UsagesService) GetSpaceUsage(organizationID, orderBy, metric, startAt, endAt string) *Collection {
+	path := fmt.Sprintf(
+		"/organizations/%s/space_periodic_usages?order=%s&metric[in]=%s&dateRange.startAt=%s&dateRange.endAt=%s",
+		organizationID,
+		orderBy,
+		metric,
+		startAt,
+		endAt,
+	)
+	method := "GET"
+
+	req, err := service.c.newRequest(method, path, nil, nil)
+	if err != nil {
+		return nil
+	}
+
+	col := NewCollection(&CollectionOptions{})
+	col.c = service.c
+	col.req = req
+
+	return col
 }

--- a/usage_test.go
+++ b/usage_test.go
@@ -1,0 +1,72 @@
+package contentful
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUsagesService_GetOrganizationUsage(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "GET")
+		assertions.Equal(r.URL.Path, "/organizations/organization_id/organization_periodic_usages?order=-usage&metric[in]=cma,cpa,gql&dateRange.startAt=2020-01-01&dateRange.endAt=2020-01-03")
+
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, readTestData("usage_organization.json"))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	res, err := cma.Usages.GetOrganizationUsage("organization_id", "-usage", "cma,cpa,gql", "2020-01-01", "2020-01-03").Next()
+	assertions.Nil(err)
+
+	usage := res.ToUsage()
+	assertions.Equal(1, len(usage))
+	assertions.Equal("<usage_metric_id>", usage[0].Sys.ID)
+	assertions.Equal("OrganizationPeriodicUsage", usage[0].Sys.Type)
+}
+
+func TestUsagesService_GetSpaceUsage(t *testing.T) {
+	var err error
+	assertions := assert.New(t)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(r.Method, "GET")
+		assertions.Equal(r.URL.Path, "/organizations/organization_id/space_periodic_usages?order=-usage&metric[in]=cma,cpa,gql&dateRange.startAt=2020-01-01&dateRange.endAt=2020-01-03")
+
+		checkHeaders(r, assertions)
+
+		w.WriteHeader(200)
+		_, _ = fmt.Fprintln(w, readTestData("usage_space.json"))
+	})
+
+	// test server
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// cma client
+	cma = NewCMA(CMAToken)
+	cma.BaseURL = server.URL
+
+	res, err := cma.Usages.GetSpaceUsage("organization_id", "-usage", "cma,cpa,gql", "2020-01-01", "2020-01-03").Next()
+	assertions.Nil(err)
+
+	usage := res.ToUsage()
+	assertions.Equal(1, len(usage))
+	assertions.Equal("<usage_metric_id>", usage[0].Sys.ID)
+	assertions.Equal("SpacePeriodicUsage", usage[0].Sys.Type)
+
+}


### PR DESCRIPTION
[CP-76], [CP-77] Added support for getting usage statistics for a specified organization.

Created the usage service which contains two methods. GetOrganizationUsage is for listing the organization's usage and GetSpaceUsage queries the organization's usage by space. The unit tests are included in the _test file.