### PR TITLE
Added missing X-Contentful-Content-Type header.

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -110,7 +110,7 @@ func (service *EntriesService) Unpublish(spaceID string, entry *Entry) error {
 }
 
 // Upsert updates or creates a new entry
-func (service *EntriesService) Upsert(spaceID string, e *Entry) error {
+func (service *EntriesService) Upsert(spaceID, contentTypeID string, e *Entry) error {
 	bytesArray, err := json.Marshal(e)
 	if err != nil {
 		return err
@@ -132,6 +132,7 @@ func (service *EntriesService) Upsert(spaceID string, e *Entry) error {
 		return err
 	}
 
+	req.Header.Set("X-Contentful-Content-Type", contentTypeID)
 	req.Header.Set("X-Contentful-Version", strconv.Itoa(e.GetVersion()))
 
 	return service.c.do(req, e)

--- a/entry_test.go
+++ b/entry_test.go
@@ -164,7 +164,7 @@ func TestEntriesService_Upsert_Create(t *testing.T) {
 		},
 	}
 
-	err = cma.Entries.Upsert(spaceID, entry)
+	err = cma.Entries.Upsert(spaceID, "hfM9RCJIk0wIm06WkEOQY", entry)
 	assertions.Nil(err)
 }
 
@@ -206,7 +206,7 @@ func TestEntriesService_Upsert_Update(t *testing.T) {
 	body := entry.Fields["body"].(map[string]interface{})
 	body["en-US"] = "Edited text"
 
-	err = cma.Entries.Upsert(spaceID, entry)
+	err = cma.Entries.Upsert(spaceID, "hfM9RCJIk0wIm06WkEOQY", entry)
 	assertions.Nil(err)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.1.4
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e // indirect
+	golang.org/x/tools v0.0.0-20200428211428-0c9eba77bc32 // indirect
 	moul.io/http2curl v1.0.1-0.20190925090545-5cd742060b0e
 )


### PR DESCRIPTION
The upsert method of the entries service was missing the content-type header. This means the API will return a missing-header error. This pull-request fixes this error, and enables the API to create and update the entries.