### PR TITLE
Fix/missing environment support

### DIFF
--- a/content_type.go
+++ b/content_type.go
@@ -421,9 +421,19 @@ func (service *ContentTypesService) doDelete(path string, ct *ContentType) error
 	return service.c.do(req, nil)
 }
 
-// Activate the contenttype, a.k.a publish
+// Activate a contenttype, a.k.a publish
 func (service *ContentTypesService) Activate(spaceID string, ct *ContentType) error {
 	path := fmt.Sprintf("/spaces/%s/content_types/%s/published", spaceID, ct.Sys.ID)
+	return service.doActivate(path, ct)
+}
+
+// Activate a contenttype in a specific environment, a.k.a publish
+func (service *ContentTypesService) ActivateEnv(env *Environment, ct *ContentType) error {
+	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s/published", env.Sys.Space.Sys.ID, env.Sys.ID, ct.Sys.ID)
+	return service.doActivate(path, ct)
+}
+
+func (service *ContentTypesService) doActivate(path string, ct *ContentType) error {
 	method := "PUT"
 
 	req, err := service.c.newRequest(method, path, nil, nil)
@@ -437,9 +447,19 @@ func (service *ContentTypesService) Activate(spaceID string, ct *ContentType) er
 	return service.c.do(req, ct)
 }
 
-// Deactivate the contenttype, a.k.a unpublish
+// Deactivate a contenttype, a.k.a publish
 func (service *ContentTypesService) Deactivate(spaceID string, ct *ContentType) error {
 	path := fmt.Sprintf("/spaces/%s/content_types/%s/published", spaceID, ct.Sys.ID)
+	return service.doDeactivate(path, ct)
+}
+
+// Deactivate a contenttype in a specific environment, a.k.a publish
+func (service *ContentTypesService) DeactivateEnv(env *Environment, ct *ContentType) error {
+	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s/published", env.Sys.Space.Sys.ID, env.Sys.ID, ct.Sys.ID)
+	return service.doDeactivate(path, ct)
+}
+
+func (service *ContentTypesService) doDeactivate(path string, ct *ContentType) error {
 	method := "DELETE"
 
 	req, err := service.c.newRequest(method, path, nil, nil)

--- a/content_type.go
+++ b/content_type.go
@@ -331,7 +331,7 @@ func (service *ContentTypesService) Get(spaceID, contentTypeID string) (*Content
 }
 
 // GetFromEnv a content type by `contentTypeID` from an environment
-func (service *ContentTypesService) GetFromEnv(env *Environment, contentTypeID string) (*ContentType, error) {
+func (service *ContentTypesService) GetWithEnv(env *Environment, contentTypeID string) (*ContentType, error) {
 	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s", env.Sys.Space.Sys.ID, env.Sys.ID, contentTypeID)
 
 	return service.doGet(path)
@@ -365,7 +365,7 @@ func (service *ContentTypesService) Upsert(spaceID string, ct *ContentType) erro
 }
 
 // UpsertEnv a content type for an environment
-func (service *ContentTypesService) UpsertEnv(env *Environment, ct *ContentType) error {
+func (service *ContentTypesService) UpsertWithEnv(env *Environment, ct *ContentType) error {
 	var path string
 
 	path = fmt.Sprintf("/spaces/%s/environments/%s", env.Sys.Space.Sys.ID, env.Sys.ID)
@@ -402,7 +402,7 @@ func (service *ContentTypesService) Delete(spaceID string, ct *ContentType) erro
 }
 
 // DeleteFromEnv a content type from an environment
-func (service *ContentTypesService) DeleteFromEnv(env *Environment, ct *ContentType) error {
+func (service *ContentTypesService) DeleteWithEnv(env *Environment, ct *ContentType) error {
 	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s", env.Sys.Space.Sys.ID, env.Sys.ID, ct.Sys.ID)
 	return service.doDelete(path, ct)
 }
@@ -428,7 +428,7 @@ func (service *ContentTypesService) Activate(spaceID string, ct *ContentType) er
 }
 
 // Activate a contenttype in a specific environment, a.k.a publish
-func (service *ContentTypesService) ActivateEnv(env *Environment, ct *ContentType) error {
+func (service *ContentTypesService) ActivateWithEnv(env *Environment, ct *ContentType) error {
 	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s/published", env.Sys.Space.Sys.ID, env.Sys.ID, ct.Sys.ID)
 	return service.doActivate(path, ct)
 }
@@ -454,7 +454,7 @@ func (service *ContentTypesService) Deactivate(spaceID string, ct *ContentType) 
 }
 
 // Deactivate a contenttype in a specific environment, a.k.a publish
-func (service *ContentTypesService) DeactivateEnv(env *Environment, ct *ContentType) error {
+func (service *ContentTypesService) DeactivateWithEnv(env *Environment, ct *ContentType) error {
 	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s/published", env.Sys.Space.Sys.ID, env.Sys.ID, ct.Sys.ID)
 	return service.doDeactivate(path, ct)
 }

--- a/content_type.go
+++ b/content_type.go
@@ -447,13 +447,13 @@ func (service *ContentTypesService) doActivate(path string, ct *ContentType) err
 	return service.c.do(req, ct)
 }
 
-// Deactivate a contenttype, a.k.a publish
+// Deactivate a contenttype, a.k.a unpublish
 func (service *ContentTypesService) Deactivate(spaceID string, ct *ContentType) error {
 	path := fmt.Sprintf("/spaces/%s/content_types/%s/published", spaceID, ct.Sys.ID)
 	return service.doDeactivate(path, ct)
 }
 
-// Deactivate a contenttype in a specific environment, a.k.a publish
+// Deactivate a contenttype in a specific environment, a.k.a unpublish
 func (service *ContentTypesService) DeactivateWithEnv(env *Environment, ct *ContentType) error {
 	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s/published", env.Sys.Space.Sys.ID, env.Sys.ID, ct.Sys.ID)
 	return service.doDeactivate(path, ct)

--- a/content_type_test.go
+++ b/content_type_test.go
@@ -68,7 +68,7 @@ func ExampleContentTypesService_Upsert_create() {
 	}
 }
 
-func ExampleContentTypesService_Upsert_create_with_environment() {
+func ExampleContentTypesService_Upsert_create_With_Environment() {
 	cma := NewCMA("cma-token")
 	env := &Environment{
 		Sys: &Sys{
@@ -179,6 +179,38 @@ func ExampleContentTypesService_Activate() {
 	}
 }
 
+func ExampleContentTypesService_Activate_With_Environment() {
+	cma := NewCMA("cma-token")
+
+	env := &Environment{
+		Sys: &Sys{
+			ID:       "env-id",
+			LinkType: "env-link-type",
+			Type:     "env-type",
+			Space: &Space{
+				Name:          "space-name",
+				DefaultLocale: "en",
+				Sys: &Sys{
+					ID:       "space-id",
+					LinkType: "space-link-type",
+					Type:     "space-type",
+				},
+			},
+		},
+		Name: "env-name",
+	}
+
+	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = cma.ContentTypes.ActivateEnv(env, contentType)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 func ExampleContentTypesService_Deactivate() {
 	cma := NewCMA("cma-token")
 
@@ -193,6 +225,38 @@ func ExampleContentTypesService_Deactivate() {
 	}
 }
 
+func ExampleContentTypesService_Deactivate_With_Environment() {
+	cma := NewCMA("cma-token")
+
+	env := &Environment{
+		Sys: &Sys{
+			ID:       "env-id",
+			LinkType: "env-link-type",
+			Type:     "env-type",
+			Space: &Space{
+				Name:          "space-name",
+				DefaultLocale: "en",
+				Sys: &Sys{
+					ID:       "space-id",
+					LinkType: "space-link-type",
+					Type:     "space-type",
+				},
+			},
+		},
+		Name: "env-name",
+	}
+
+	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = cma.ContentTypes.DeactivateEnv(env, contentType)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 func ExampleContentTypesService_Delete() {
 	cma := NewCMA("cma-token")
 
@@ -202,6 +266,38 @@ func ExampleContentTypesService_Delete() {
 	}
 
 	err = cma.ContentTypes.Delete("space-id", contentType)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleContentTypesService_Delete_With_Environment() {
+	cma := NewCMA("cma-token")
+
+	env := &Environment{
+		Sys: &Sys{
+			ID:       "env-id",
+			LinkType: "env-link-type",
+			Type:     "env-type",
+			Space: &Space{
+				Name:          "space-name",
+				DefaultLocale: "en",
+				Sys: &Sys{
+					ID:       "space-id",
+					LinkType: "space-link-type",
+					Type:     "space-type",
+				},
+			},
+		},
+		Name: "env-name",
+	}
+
+	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = cma.ContentTypes.DeleteFromEnv(env, contentType)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/content_type_test.go
+++ b/content_type_test.go
@@ -48,7 +48,7 @@ func ExampleContentTypesService_Upsert_create() {
 	}
 }
 
-func ExampleContentTypesService_Upsert_create_With_Environment() {
+func ExampleContentTypesService_Upsert_create_with_environment() {
 	cma := NewCMA("cma-token")
 	env, _ := environmentFromTestData("environment_1.json")
 	ct, _ := contentTypeFromTestData("content_type.json")
@@ -75,7 +75,7 @@ func ExampleContentTypesService_Upsert_update() {
 	}
 }
 
-func ExampleContentTypesService_Upsert_Update_With_Environment() {
+func ExampleContentTypesService_Upsert_update_with_environment() {
 	cma := NewCMA("cma-token")
 	env, _ := environmentFromTestData("environment_1.json")
 
@@ -106,7 +106,7 @@ func ExampleContentTypesService_Activate() {
 	}
 }
 
-func ExampleContentTypesService_Activate_With_Environment() {
+func ExampleContentTypesService_Activate_with_environment() {
 	cma := NewCMA("cma-token")
 
 	env, _ := environmentFromTestData("environment_1.json")
@@ -136,7 +136,7 @@ func ExampleContentTypesService_Deactivate() {
 	}
 }
 
-func ExampleContentTypesService_Deactivate_With_Environment() {
+func ExampleContentTypesService_Deactivate_with_environment() {
 	cma := NewCMA("cma-token")
 
 	env, _ := environmentFromTestData("environment_1.json")
@@ -166,22 +166,6 @@ func ExampleContentTypesService_Delete() {
 	}
 }
 
-func ExampleContentTypesService_Delete_With_Environment() {
-	cma := NewCMA("cma-token")
-
-	env, _ := environmentFromTestData("environment_1.json")
-
-	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = cma.ContentTypes.DeleteWithEnv(env, contentType)
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
 func ExampleContentTypesService_Delete_with_environment() {
 	cma := NewCMA("cma-token")
 
@@ -198,7 +182,7 @@ func ExampleContentTypesService_Delete_with_environment() {
 	}
 }
 
-func ExampleContentTypesService_Delete_allDrafts() {
+func ExampleContentTypesService_Delete_all_drafts() {
 	cma := NewCMA("cma-token")
 
 	collection, err := cma.ContentTypes.List("space-id").Next()
@@ -218,7 +202,7 @@ func ExampleContentTypesService_Delete_allDrafts() {
 	}
 }
 
-func TestContentTypesServiceList(t *testing.T) {
+func TestContentTypesService_List(t *testing.T) {
 	var err error
 	assertions := assert.New(t)
 
@@ -247,7 +231,7 @@ func TestContentTypesServiceList(t *testing.T) {
 	assertions.Equal("City", contentType[0].Name)
 }
 
-func TestContentTypesServiceListActivated(t *testing.T) {
+func TestContentTypesService_ListActivated(t *testing.T) {
 	var err error
 	assertions := assert.New(t)
 
@@ -360,7 +344,7 @@ func TestContentTypesService_Get_2(t *testing.T) {
 	assertions.NotNil(err)
 }
 
-func TestContentTypesServiceActivate(t *testing.T) {
+func TestContentTypesService_Activate(t *testing.T) {
 	var err error
 	assertions := assert.New(t)
 
@@ -390,7 +374,7 @@ func TestContentTypesServiceActivate(t *testing.T) {
 	assertions.Nil(err)
 }
 
-func TestContentTypesServiceActivateForEnv(t *testing.T) {
+func TestContentTypesService_Activate_with_env(t *testing.T) {
 	var err error
 	assertions := assert.New(t)
 	env, err := environmentFromTestData("environment_1.json")
@@ -423,7 +407,7 @@ func TestContentTypesServiceActivateForEnv(t *testing.T) {
 	assertions.Nil(err)
 }
 
-func TestContentTypesServiceDeactivate(t *testing.T) {
+func TestContentTypesService_Deactivate(t *testing.T) {
 	var err error
 	assertions := assert.New(t)
 
@@ -453,7 +437,7 @@ func TestContentTypesServiceDeactivate(t *testing.T) {
 	assertions.Nil(err)
 }
 
-func TestContentTypesServiceDeactivateForEnv(t *testing.T) {
+func TestContentTypesService_Deactivate_with_env(t *testing.T) {
 	var err error
 	assertions := assert.New(t)
 	env, err := environmentFromTestData("environment_1.json")

--- a/content_type_test.go
+++ b/content_type_test.go
@@ -40,29 +40,9 @@ func ExampleContentTypesService_List() {
 func ExampleContentTypesService_Upsert_create() {
 	cma := NewCMA("cma-token")
 
-	contentType := &ContentType{
-		Name:         "test content type",
-		DisplayField: "field1_id",
-		Description:  "content type description",
-		Fields: []*Field{
-			{
-				ID:       "field1_id",
-				Name:     "field1",
-				Type:     "Symbol",
-				Required: false,
-				Disabled: false,
-			},
-			{
-				ID:       "field2_id",
-				Name:     "field2",
-				Type:     "Symbol",
-				Required: false,
-				Disabled: true,
-			},
-		},
-	}
+	ct, _ := contentTypeFromTestData("content_type.json")
 
-	err := cma.ContentTypes.Upsert("space-id", contentType)
+	err := cma.ContentTypes.Upsert("space-id", ct)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -70,47 +50,10 @@ func ExampleContentTypesService_Upsert_create() {
 
 func ExampleContentTypesService_Upsert_create_With_Environment() {
 	cma := NewCMA("cma-token")
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       "space-id",
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
+	env, _ := environmentFromTestData("environment_1.json")
+	ct, _ := contentTypeFromTestData("content_type.json")
 
-	contentType := &ContentType{
-		Name:         "test content type",
-		DisplayField: "field1_id",
-		Description:  "content type description",
-		Fields: []*Field{
-			{
-				ID:       "field1_id",
-				Name:     "field1",
-				Type:     "Symbol",
-				Required: false,
-				Disabled: false,
-			},
-			{
-				ID:       "field2_id",
-				Name:     "field2",
-				Type:     "Symbol",
-				Required: false,
-				Disabled: true,
-			},
-		},
-	}
-
-	err := cma.ContentTypes.UpsertWithEnv(env, contentType)
+	err := cma.ContentTypes.UpsertWithEnv(env, ct)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -134,23 +77,7 @@ func ExampleContentTypesService_Upsert_update() {
 
 func ExampleContentTypesService_Upsert_Update_With_Environment() {
 	cma := NewCMA("cma-token")
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       "space-id",
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
+	env, _ := environmentFromTestData("environment_1.json")
 
 	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
 	if err != nil {
@@ -182,23 +109,7 @@ func ExampleContentTypesService_Activate() {
 func ExampleContentTypesService_Activate_With_Environment() {
 	cma := NewCMA("cma-token")
 
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       "space-id",
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
+	env, _ := environmentFromTestData("environment_1.json")
 
 	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
 	if err != nil {
@@ -228,23 +139,7 @@ func ExampleContentTypesService_Deactivate() {
 func ExampleContentTypesService_Deactivate_With_Environment() {
 	cma := NewCMA("cma-token")
 
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       "space-id",
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
+	env, _ := environmentFromTestData("environment_1.json")
 
 	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
 	if err != nil {
@@ -274,23 +169,7 @@ func ExampleContentTypesService_Delete() {
 func ExampleContentTypesService_Delete_With_Environment() {
 	cma := NewCMA("cma-token")
 
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       "space-id",
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
+	env, _ := environmentFromTestData("environment_1.json")
 
 	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
 	if err != nil {
@@ -306,23 +185,7 @@ func ExampleContentTypesService_Delete_With_Environment() {
 func ExampleContentTypesService_Delete_with_environment() {
 	cma := NewCMA("cma-token")
 
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       "space-id",
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
+	env, _ := environmentFromTestData("environment_1.json")
 
 	contentType, err := cma.ContentTypes.GetWithEnv(env, "content-type-id")
 	if err != nil {
@@ -440,27 +303,13 @@ func TestContentTypesService_Get(t *testing.T) {
 func TestContentTypesService_GetFromEnv(t *testing.T) {
 	var err error
 	assertions := assert.New(t)
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       spaceID,
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
+	env, err := environmentFromTestData("environment_1.json")
+	assertions.Nil(err)
+	assertions.NotNil(env)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "GET")
-		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/environments/env-id/content_types/63Vgs0BFK0USe4i2mQUGK6")
+		assertions.Equal(r.URL.Path, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/63Vgs0BFK0USe4i2mQUGK6")
 
 		checkHeaders(r, assertions)
 
@@ -544,27 +393,13 @@ func TestContentTypesServiceActivate(t *testing.T) {
 func TestContentTypesServiceActivateForEnv(t *testing.T) {
 	var err error
 	assertions := assert.New(t)
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       spaceID,
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
+	env, err := environmentFromTestData("environment_1.json")
+	assertions.Nil(err)
+	assertions.NotNil(env)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "PUT")
-		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/environments/env-id/content_types/63Vgs0BFK0USe4i2mQUGK6/published")
+		assertions.Equal(r.URL.Path, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/63Vgs0BFK0USe4i2mQUGK6/published")
 
 		checkHeaders(r, assertions)
 
@@ -621,27 +456,13 @@ func TestContentTypesServiceDeactivate(t *testing.T) {
 func TestContentTypesServiceDeactivateForEnv(t *testing.T) {
 	var err error
 	assertions := assert.New(t)
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       spaceID,
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
+	env, err := environmentFromTestData("environment_1.json")
+	assertions.Nil(err)
+	assertions.NotNil(env)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "DELETE")
-		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/environments/env-id/content_types/63Vgs0BFK0USe4i2mQUGK6/published")
+		assertions.Equal(r.URL.Path, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/63Vgs0BFK0USe4i2mQUGK6/published")
 
 		checkHeaders(r, assertions)
 
@@ -885,27 +706,13 @@ func TestContentTypeDelete(t *testing.T) {
 func TestContentTypesServiceDeleteFromEnv(t *testing.T) {
 	var err error
 	assertions := assert.New(t)
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       spaceID,
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
+	env, err := environmentFromTestData("environment_1.json")
+	assertions.Nil(err)
+	assertions.NotNil(env)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "DELETE")
-		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/environments/env-id/content_types/63Vgs0BFK0USe4i2mQUGK6")
+		assertions.Equal(r.URL.Path, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/63Vgs0BFK0USe4i2mQUGK6")
 
 		checkHeaders(r, assertions)
 


### PR DESCRIPTION
Adds environment support to the activate, de-activate and delete functions. Also adds missing tests. The functions are renamed, to avoid confusing function names (fe: GetFromEnv and UpsertEnv are named GetWithEnv and UpsertWithEnv).